### PR TITLE
GitHub Copilot用のカスタムプロンプト追加

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,11 @@
+## Code Review Language
+Always provide code review feedback and suggestions in Japanese.
+
+## Code Review Focus Areas
+When reviewing code, pay attention to:
+- Is business logic properly separated from UI components?
+- Are custom hooks being used effectively for state management?
+- Is the single responsibility principle being followed?
+- Are manager classes handling domain logic appropriately?
+- Is error handling implemented correctly?
+- Are React best practices being followed (proper useEffect dependencies, cleanup, etc.)?


### PR DESCRIPTION
## 概要
PRのレビューを円滑に行うためにGitHub Copilot用のカスタムプロンプト追加

## チケットへのリンク
https://github.com/Yanai1005/giganoto-front/issues/33
## マージを希望するか
- [x] 希望する
- [] 希望しない

## 行った作業
- プロンプトふぁいるを追加
- 
- 
## できるようになること（ユーザ目線）
* 何ができるようになるのか？（あれば。無いなら「無し」でOK）

## できなくなること（ユーザ目線）
* 何ができなくなるのか？（あれば。無いなら「無し」でOK）

## 動作確認
* どのような動作確認を行ったのか？ 結果はどうか？

## その他
（実装上の懸念点や注意点などあれば記載）
