### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,9 @@ on:
       - 'Docs/**'
       - 'giganoto-infra/**'  
 
+permissions:
+  contents: read
+
 env:
   GCP_PROJECT_ID: giganoto-463603
   GCP_REGION: asia-northeast1


### PR DESCRIPTION
Potential fix for [https://github.com/Yanai1005/giganoto-front/security/code-scanning/1](https://github.com/Yanai1005/giganoto-front/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function correctly. Based on the workflow's operations, it primarily interacts with Google Cloud and does not seem to require write access to the repository. Therefore, we will set `contents: read` as the minimal permission. If additional permissions are required for specific actions, they can be added later.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
